### PR TITLE
fix: use `discord.com` domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const app = express();
 // app.use(bodyParser.json());
 
 const discord_api = axios.create({
-  baseURL: 'https://discordapp.com/api/',
+  baseURL: 'https://discord.com/api/',
   timeout: 3000,
   headers: {
 	"Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
discordapp.com domain is deprecated for newer API version.